### PR TITLE
Improve mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <!-- Use the app icon for the favicon. The PWA plugin will inject additional
          icon links when building for production. -->
     <link rel="icon" type="image/png" href="/pwa-192x192.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover ensures use of the full screen on modern mobile devices -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#00C0BF" />
     <meta name="description" content="Realtime dashboard and trip analysis for EV owners" />
     <link rel="apple-touch-icon" href="/pwa-192x192.png">

--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -11,7 +11,8 @@ export default function TabBar({ activeTab, setActiveTab }) {
 
   return (
     <nav
-      className="left-0 right-0 w-full h-16 flex justify-around items-center bg-card/90 backdrop-blur shadow-lg"
+      /* Fixed positioning keeps the navigation accessible on mobile */
+      className="fixed bottom-0 left-0 right-0 z-10 w-full h-16 flex justify-around items-center bg-card/90 backdrop-blur shadow-lg"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
       data-testid="tabbar"
     >


### PR DESCRIPTION
## Summary
- keep TabBar fixed at the bottom for easier navigation on phones
- enable full-screen mode for mobile with `viewport-fit=cover`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889de3291e0832484de23a91f02ab00